### PR TITLE
Support transformers 4.51.0 and Qwen3 in PTQ + LiteML export

### DIFF
--- a/eval_utils/gptq_utils.py
+++ b/eval_utils/gptq_utils.py
@@ -228,6 +228,12 @@ def gptq_fwrd(model, dataloader, dev, args):
             cache["i"] += 1
             cache["attention_mask"] = kwargs["attention_mask"]
             cache["position_ids"] = kwargs["position_ids"]
+            # transformers >= 4.51 computes position_embeddings (cos, sin) once in the
+            # top-level model forward and passes it to every decoder layer; the layer no
+            # longer derives it internally. Capture it here so the standalone layer calls
+            # below can forward it. On < 4.51 this kwarg is absent (-> None), which the
+            # older layer forward still accepts and computes internally.
+            cache["position_embeddings"] = kwargs.get("position_embeddings", None)
             raise ValueError
 
     layers[0] = Catcher(layers[0])
@@ -246,6 +252,7 @@ def gptq_fwrd(model, dataloader, dev, args):
     outs = torch.zeros_like(inps)
     attention_mask = cache["attention_mask"]
     position_ids = cache["position_ids"]
+    position_embeddings = cache["position_embeddings"]
 
     quantizers = {}
     sequential = [
@@ -300,6 +307,7 @@ def gptq_fwrd(model, dataloader, dev, args):
                     inps[j].unsqueeze(0),
                     attention_mask=attention_mask,
                     position_ids=position_ids,
+                    position_embeddings=position_embeddings,
                 )[0]
             for h in handles:
                 h.remove()
@@ -321,6 +329,7 @@ def gptq_fwrd(model, dataloader, dev, args):
                 inps[j].unsqueeze(0),
                 attention_mask=attention_mask,
                 position_ids=position_ids,
+                position_embeddings=position_embeddings,
             )[0]
 
         layers[i] = layer.cpu()

--- a/liteml_state_dict.py
+++ b/liteml_state_dict.py
@@ -3,6 +3,12 @@ import argparse
 from collections import OrderedDict
 
 
+# RMSNorm submodules exported as plain norm weights: kept as-is in the standard export,
+# renamed to "<name>._RMSnorm.weight" in TrueQuant mode (to match LiteML's TrueQuantRMSNorm).
+# Includes the Qwen3 per-head q_norm/k_norm in addition to the decoder layer norms.
+_NORM_MODULES = ('input_layernorm', 'post_attention_layernorm', 'q_norm', 'k_norm')
+
+
 def convert_spinquant_zp_for_liteml(value):
     """Convert SpinQuant asymmetric zero-points (unsigned domain) to LiteML signed qint domain."""
     if getattr(value, "sym", True):
@@ -65,7 +71,10 @@ def export_retrainer_model(state_dict, group_size):
 
     for key, value in state_dict['model'].items():
         last, before_last = key.split('.')[-1], key.split('.')[-2]
-        if 'layernorm' in key:
+        # Norm layers (incl. Qwen3 per-head q_norm/k_norm) are plain RMSNorm, not Linear
+        # modules — keep their keys as-is so they are not mangled into the quantized
+        # Linear "_model.weight" form.
+        if before_last in _NORM_MODULES:
             liteml_state_dict[key] = value
         elif key == 'model.embed_tokens.weight' or key == 'model.norm.weight':
             liteml_state_dict[key] = value
@@ -99,7 +108,7 @@ def export_retrainer_model_TrueQuantRMSNorm(state_dict, group_size):
 
     for key, value in state_dict['model'].items():
         last, before_last = key.split('.')[-1], key.split('.')[-2]
-        if 'layernorm' in key or key == 'model.norm.weight':
+        if before_last in _NORM_MODULES or key == 'model.norm.weight':
             key = key.replace('weight', '_RMSnorm.weight')  # change RMSnorm key according to TrueQuantRMSNorm implementation
             liteml_state_dict[key] = value
         elif key == 'model.embed_tokens.weight':
@@ -134,7 +143,7 @@ def export_retrainer_model_fuse_lm_head_TrueQuantRMSNorm(state_dict, group_size,
 
     for key, value in state_dict['model'].items():
         last, before_last = key.split('.')[-1], key.split('.')[-2]
-        if 'layernorm' in key:
+        if before_last in _NORM_MODULES:
             if true_quant:
                 key = key.replace('weight', '_RMSnorm.weight')  # change RMSnorm key according to TrueQuantRMSNorm implementation
             liteml_state_dict[key] = value

--- a/ptq.py
+++ b/ptq.py
@@ -37,10 +37,10 @@ def train() -> None:
         process_word_embeddings = True
     dtype = torch.bfloat16 if training_args.bf16 else torch.float16
 
-    # Some architectures (e.g. Qwen2) require eager attention to avoid issues
+    # Some architectures (e.g. Qwen2/Qwen3) require eager attention to avoid issues
     # with custom attention implementations during quantization/rotation.
     # Note: DeepSeek-R1-Distill-Qwen models also use model_type="qwen2" and are covered here.
-    _EAGER_ATTN_ARCHS = {"qwen2"}
+    _EAGER_ATTN_ARCHS = {"qwen2", "qwen3"}
     arch = getattr(config, "model_type", "").lower()
     model_kwargs = dict(
         pretrained_model_name_or_path=model_args.input_model,

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,4 +1,4 @@
-transformers==4.44.2
+transformers==4.51.0
 accelerate==0.34.2
 datasets==2.20.0
 sentencepiece

--- a/utils/eval_utils.py
+++ b/utils/eval_utils.py
@@ -60,6 +60,12 @@ def evaluator(model, testenc, dev, args):
             cache["i"] += 1
             cache["attention_mask"] = kwargs["attention_mask"]
             cache["position_ids"] = kwargs["position_ids"]
+            # transformers >= 4.51 computes position_embeddings (cos, sin) once in the
+            # top-level model forward and passes it to every decoder layer; the layer no
+            # longer derives it internally. Capture it here so the standalone layer calls
+            # below can forward it. On < 4.51 this kwarg is absent (-> None), which the
+            # older layer forward still accepts and computes internally.
+            cache["position_embeddings"] = kwargs.get("position_embeddings", None)
             raise ValueError
 
     layers[0] = Catcher(layers[0])
@@ -79,6 +85,7 @@ def evaluator(model, testenc, dev, args):
     torch.cuda.empty_cache()
     outs = [0] * nbatches
     attention_mask = cache["attention_mask"]
+    position_embeddings = cache["position_embeddings"]
 
     for i in tqdm(range(len(layers)), desc="(Eval) Layers"):
         layer = layers[i].to(dev)
@@ -97,6 +104,7 @@ def evaluator(model, testenc, dev, args):
                 attention_mask=attention_mask,
                 #  defined.
                 position_ids=position_ids,
+                position_embeddings=position_embeddings,
             )[0]
         layers[i] = layer.cpu()
         del layer


### PR DESCRIPTION
- Bump transformers 4.44.2 -> 4.51.0 (requirement.txt).
- Thread position_embeddings (cos, sin) through the standalone decoder-layer calls in gptq_fwrd and evaluator. In transformers >= 4.51 the top-level model computes rotary embeddings once and passes them to every layer; the layer no longer derives them, so running layers in isolation crashed on `cos, sin = position_embeddings` (None). Captured via the Catcher and forwarded; falls back to None on < 4.51 for backward compatibility.
- Enable eager attention for both qwen2 and qwen3 during quantization/rotation.
- Export Qwen3 per-head q_norm/k_norm RMSNorm weights correctly across all export modes via a shared _NORM_MODULES tuple: kept as-is in standard export, renamed to `._RMSnorm.weight` in TrueQuant mode (previously mangled into the Linear `._model.weight` form).